### PR TITLE
contracts/stake: fixed typing error(OWnable -> Ownable)

### DIFF
--- a/contracts/stake/RootChainRegistry.sol
+++ b/contracts/stake/RootChainRegistry.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.12;
 
-import { Ownable } from "../../node_modules/openzeppelin-solidity/contracts/ownership/OWnable.sol";
+import { Ownable } from "../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 import { RootChainI } from "../RootChainI.sol";
 

--- a/contracts/stake/managers/DepositManager.sol
+++ b/contracts/stake/managers/DepositManager.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.12;
 
-import { Ownable } from "../../../node_modules/openzeppelin-solidity/contracts/ownership/OWnable.sol";
+import { Ownable } from "../../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { SafeMath } from "../../../node_modules/openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { IERC20 } from "../../../node_modules/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "../../../node_modules/openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";

--- a/contracts/stake/tokens/ERC20MultiTransfer.sol
+++ b/contracts/stake/tokens/ERC20MultiTransfer.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.12;
 
-import { Ownable } from "../../../node_modules/openzeppelin-solidity/contracts/ownership/OWnable.sol";
+import { Ownable } from "../../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import { IERC20 } from "../../../node_modules/openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "../../../node_modules/openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 


### PR DESCRIPTION
fixed "OWnable" to "Ownable"

Because of this, it couldn't compile in Ubuntu.